### PR TITLE
Track sync status per provider

### DIFF
--- a/src/main/java/com/sportygroup/f1betting/configuration/F1ApiConfig.java
+++ b/src/main/java/com/sportygroup/f1betting/configuration/F1ApiConfig.java
@@ -3,6 +3,7 @@ package com.sportygroup.f1betting.configuration;
 import com.sportygroup.f1betting.external.F1ExternalApi;
 import com.sportygroup.f1betting.external.client.OpenF1Client;
 import com.sportygroup.f1betting.properties.F1ApiProperties;
+import com.sportygroup.f1betting.entity.ProviderName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -18,10 +19,16 @@ public class F1ApiConfig {
     @Bean
     public F1ExternalApi f1ExternalApi(OpenF1Client openF1) {
 
-        return switch (props.getActiveProvider()) {
-            case "openf1" -> openF1;
-            default -> throw new IllegalStateException(
-                "Unknown provider: " + props.getActiveProvider());
+        ProviderName provider;
+        try {
+            provider = ProviderName.valueOf(props.getActiveProvider().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException("Unknown provider: " + props.getActiveProvider());
+        }
+
+        return switch (provider) {
+            case OPENF1 -> openF1;
+            default -> throw new IllegalStateException("Provider not supported: " + provider);
         };
     }
 }

--- a/src/main/java/com/sportygroup/f1betting/entity/DriverExternalRef.java
+++ b/src/main/java/com/sportygroup/f1betting/entity/DriverExternalRef.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -18,6 +20,8 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.UUID;
+
+import com.sportygroup.f1betting.entity.ProviderName;
 
 @Getter
 @Setter
@@ -31,10 +35,10 @@ public class DriverExternalRef {
     @Column(name = "id", nullable = false)
     private UUID id;
 
-    @Size(max = 50)
+    @Enumerated(EnumType.STRING)
     @NotNull
     @Column(name = "provider_name", nullable = false, length = 50)
-    private String providerName;
+    private ProviderName providerName;
 
     @Size(max = 100)
     @NotNull

--- a/src/main/java/com/sportygroup/f1betting/entity/EventExternalRef.java
+++ b/src/main/java/com/sportygroup/f1betting/entity/EventExternalRef.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -18,6 +20,8 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.UUID;
+
+import com.sportygroup.f1betting.entity.ProviderName;
 
 @Getter
 @Setter
@@ -31,10 +35,10 @@ public class EventExternalRef {
     @Column(name = "id", nullable = false)
     private UUID id;
 
-    @Size(max = 50)
+    @Enumerated(EnumType.STRING)
     @NotNull
     @Column(name = "provider_name", nullable = false, length = 50)
-    private String providerName;
+    private ProviderName providerName;
 
     @Size(max = 100)
     @NotNull

--- a/src/main/java/com/sportygroup/f1betting/entity/ProviderName.java
+++ b/src/main/java/com/sportygroup/f1betting/entity/ProviderName.java
@@ -1,0 +1,13 @@
+package com.sportygroup.f1betting.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ProviderName {
+    OPENF1,
+    ERGAST;
+
+    @JsonValue
+    public String toJson() {
+        return name().toLowerCase();
+    }
+}

--- a/src/main/java/com/sportygroup/f1betting/entity/SyncStatus.java
+++ b/src/main/java/com/sportygroup/f1betting/entity/SyncStatus.java
@@ -2,6 +2,8 @@ package com.sportygroup.f1betting.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -9,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -16,14 +19,24 @@ import java.time.Instant;
 @Entity
 @Table(name = "sync_status")
 public class SyncStatus {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "provider_name", nullable = false, length = 50)
+    private String providerName;
+
     @Column(name = "year", nullable = false)
     private Integer year;
 
     @Column(name = "last_synced", nullable = false)
     private Instant lastSynced;
 
-    public SyncStatus(Integer year, Instant lastSynced) {
+    public SyncStatus(UUID id, String providerName, Integer year, Instant lastSynced) {
+        this.id = id;
+        this.providerName = providerName;
         this.year = year;
         this.lastSynced = lastSynced;
     }

--- a/src/main/java/com/sportygroup/f1betting/external/dto/ExternalEventDto.java
+++ b/src/main/java/com/sportygroup/f1betting/external/dto/ExternalEventDto.java
@@ -1,12 +1,13 @@
 package com.sportygroup.f1betting.external.dto;
 
 import lombok.Builder;
+import com.sportygroup.f1betting.entity.ProviderName;
 
 import java.time.OffsetDateTime;
 
 @Builder
 public record ExternalEventDto(String externalEventId,
-                               String providerName,
+                               ProviderName providerName,
                                String eventName,
                                String eventType,
                                Integer year,

--- a/src/main/java/com/sportygroup/f1betting/external/dto/openf1/OpenF1SessionDto.java
+++ b/src/main/java/com/sportygroup/f1betting/external/dto/openf1/OpenF1SessionDto.java
@@ -1,6 +1,7 @@
 package com.sportygroup.f1betting.external.dto.openf1;
 
 import com.sportygroup.f1betting.external.dto.ExternalEventDto;
+import com.sportygroup.f1betting.entity.ProviderName;
 
 import java.time.OffsetDateTime;
 
@@ -16,7 +17,7 @@ public record OpenF1SessionDto(String sessionKey,
     public ExternalEventDto toEventSearchDto() {
         return ExternalEventDto.builder()
             .externalEventId(this.sessionKey)
-            .providerName("openf1")
+            .providerName(ProviderName.OPENF1)
             .eventName(this.sessionName)
             .eventType(this.sessionType)
             .year(this.year)

--- a/src/main/java/com/sportygroup/f1betting/repository/EventExternalRefRepository.java
+++ b/src/main/java/com/sportygroup/f1betting/repository/EventExternalRefRepository.java
@@ -1,11 +1,12 @@
 package com.sportygroup.f1betting.repository;
 
 import com.sportygroup.f1betting.entity.EventExternalRef;
+import com.sportygroup.f1betting.entity.ProviderName;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface EventExternalRefRepository extends JpaRepository<EventExternalRef, UUID> {
-    Optional<EventExternalRef> findByProviderNameAndExternalId(String providerName, String externalId);
+    Optional<EventExternalRef> findByProviderNameAndExternalId(ProviderName providerName, String externalId);
 }

--- a/src/main/java/com/sportygroup/f1betting/repository/SyncStatusRepository.java
+++ b/src/main/java/com/sportygroup/f1betting/repository/SyncStatusRepository.java
@@ -7,10 +7,13 @@ import org.springframework.data.jpa.repository.Query;
 
 import jakarta.persistence.LockModeType;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface SyncStatusRepository extends JpaRepository<SyncStatus, Integer> {
+public interface SyncStatusRepository extends JpaRepository<SyncStatus, UUID> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select s from SyncStatus s where s.year = :year")
-    Optional<SyncStatus> findByYearForUpdate(Integer year);
+    @Query("select s from SyncStatus s where s.providerName = :provider and s.year = :year")
+    Optional<SyncStatus> findByProviderAndYearForUpdate(String provider, Integer year);
+
+    Optional<SyncStatus> findByProviderNameAndYear(String provider, Integer year);
 }

--- a/src/main/java/com/sportygroup/f1betting/service/SyncService.java
+++ b/src/main/java/com/sportygroup/f1betting/service/SyncService.java
@@ -5,10 +5,10 @@ import com.sportygroup.f1betting.entity.EventExternalRef;
 import com.sportygroup.f1betting.entity.SyncStatus;
 import com.sportygroup.f1betting.external.F1ExternalApi;
 import com.sportygroup.f1betting.external.dto.ExternalEventDto;
+import com.sportygroup.f1betting.properties.F1ApiProperties;
 import com.sportygroup.f1betting.repository.EventExternalRefRepository;
 import com.sportygroup.f1betting.repository.EventRepository;
 import com.sportygroup.f1betting.repository.SyncStatusRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class SyncService {
 
@@ -28,17 +27,30 @@ public class SyncService {
     private final EventRepository eventRepository;
     private final EventExternalRefRepository eventExternalRefRepository;
     private final F1ExternalApi f1ExternalApi;
+    private final String provider;
+
+    public SyncService(SyncStatusRepository syncStatusRepository,
+                       EventRepository eventRepository,
+                       EventExternalRefRepository eventExternalRefRepository,
+                       F1ExternalApi f1ExternalApi,
+                       F1ApiProperties properties) {
+        this.syncStatusRepository = syncStatusRepository;
+        this.eventRepository = eventRepository;
+        this.eventExternalRefRepository = eventExternalRefRepository;
+        this.f1ExternalApi = f1ExternalApi;
+        this.provider = properties.getActiveProvider();
+    }
 
     @Transactional
     public void syncYear(int year) {
         Instant epoch = Instant.EPOCH;
-        if (!syncStatusRepository.existsById(year)) {
-            syncStatusRepository.saveAndFlush(new SyncStatus(year, epoch));
+        if (syncStatusRepository.findByProviderNameAndYear(provider, year).isEmpty()) {
+            syncStatusRepository.saveAndFlush(new SyncStatus(null, provider, year, epoch));
         }
 
-        SyncStatus status = syncStatusRepository.findByYearForUpdate(year)
+        SyncStatus status = syncStatusRepository.findByProviderAndYearForUpdate(provider, year)
             .orElseThrow();
-        log.info("Year {} locked for sync", year);
+        log.info("Provider {} year {} locked for sync", provider, year);
 
         int currentYear = Year.now().getValue();
         Instant now = Instant.now();
@@ -54,14 +66,14 @@ public class SyncService {
         }
 
         List<ExternalEventDto> events = f1ExternalApi.listEvents(year, null, null);
-        log.info("Fetched {} events for year {}", events.size(), year);
+        log.info("Fetched {} events for provider {} year {}", events.size(), provider, year);
         for (ExternalEventDto dto : events) {
             upsertEvent(dto);
         }
 
         status.setLastSynced(now);
         syncStatusRepository.save(status);
-        log.info("Sync for year {} finished", year);
+        log.info("Sync for provider {} year {} finished", provider, year);
     }
 
     void upsertEvent(ExternalEventDto dto) {

--- a/src/main/resources/db/migration/V6__sync_status_per_provider.sql
+++ b/src/main/resources/db/migration/V6__sync_status_per_provider.sql
@@ -1,0 +1,10 @@
+-- V6__sync_status_per_provider.sql
+DROP TABLE IF EXISTS sync_status;
+
+CREATE TABLE sync_status (
+    id UUID PRIMARY KEY,
+    provider_name VARCHAR(50) NOT NULL,
+    year INTEGER NOT NULL,
+    last_synced TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uq_sync_status_provider_year UNIQUE (provider_name, year)
+);

--- a/src/test/java/com/sportygroup/f1betting/controller/EventControllerIntegrationTest.java
+++ b/src/test/java/com/sportygroup/f1betting/controller/EventControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sportygroup.f1betting.entity.Event;
 import com.sportygroup.f1betting.entity.EventExternalRef;
+import com.sportygroup.f1betting.entity.ProviderName;
 import com.sportygroup.f1betting.external.dto.ExternalEventDto;
 import com.sportygroup.f1betting.repository.EventExternalRefRepository;
 import com.sportygroup.f1betting.repository.EventRepository;
@@ -55,7 +56,7 @@ class EventControllerIntegrationTest {
         e1.setDateStart(OffsetDateTime.parse("2023-08-27T14:00:00Z"));
         eventRepository.save(e1);
         EventExternalRef ref1 = new EventExternalRef();
-        ref1.setProviderName("openf1");
+        ref1.setProviderName(ProviderName.OPENF1);
         ref1.setExternalId("1");
         ref1.setEvent(e1);
         eventExternalRefRepository.save(ref1);
@@ -68,7 +69,7 @@ class EventControllerIntegrationTest {
         e2.setDateStart(OffsetDateTime.parse("2024-08-25T14:00:00Z"));
         eventRepository.save(e2);
         EventExternalRef ref2 = new EventExternalRef();
-        ref2.setProviderName("openf1");
+        ref2.setProviderName(ProviderName.OPENF1);
         ref2.setExternalId("2");
         ref2.setEvent(e2);
         eventExternalRefRepository.save(ref2);

--- a/src/test/java/com/sportygroup/f1betting/service/SyncServiceTest.java
+++ b/src/test/java/com/sportygroup/f1betting/service/SyncServiceTest.java
@@ -2,6 +2,8 @@ package com.sportygroup.f1betting.service;
 
 import com.sportygroup.f1betting.external.F1ExternalApi;
 import com.sportygroup.f1betting.external.dto.ExternalEventDto;
+import com.sportygroup.f1betting.entity.ProviderName;
+import com.sportygroup.f1betting.properties.F1ApiProperties;
 import com.sportygroup.f1betting.repository.EventExternalRefRepository;
 import com.sportygroup.f1betting.repository.EventRepository;
 import com.sportygroup.f1betting.repository.SyncStatusRepository;
@@ -31,7 +33,7 @@ class SyncServiceTest {
 
         ExternalEventDto first = ExternalEventDto.builder()
             .externalEventId("A")
-            .providerName("openf1")
+            .providerName(ProviderName.OPENF1)
             .eventName("Race")
             .eventType("Race")
             .year(2024)
@@ -42,7 +44,7 @@ class SyncServiceTest {
 
         ExternalEventDto second = ExternalEventDto.builder()
             .externalEventId("B")
-            .providerName("ergast")
+            .providerName(ProviderName.ERGAST)
             .eventName("Race")
             .eventType("Race")
             .year(2024)
@@ -68,6 +70,8 @@ class SyncServiceTest {
                 return Collections.emptyList();
             }
         };
-        return new SyncService(syncStatusRepository, eventRepository, eventExternalRefRepository, dummy);
+        F1ApiProperties props = new F1ApiProperties();
+        props.setActiveProvider("openf1");
+        return new SyncService(syncStatusRepository, eventRepository, eventExternalRefRepository, dummy, props);
     }
 }


### PR DESCRIPTION
## Summary
- add migration for provider-aware sync_status table
- add `ProviderName` enum for supported external providers
- expand entities and repositories to include provider information
- refactor `SyncService` to lock and throttle per provider-year
- adjust tests for provider-aware sync status

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687f33c976f083218bf78054d791db81